### PR TITLE
csc: Rename VolumeInfo to Volume in listVolumesFormat

### DIFF
--- a/csc/cmd/formats.go
+++ b/csc/cmd/formats.go
@@ -10,7 +10,7 @@ const volumeInfoFormat = `{{printf "%q\t%d" .Id .CapacityBytes}}` +
 // listVolumesFormat is the default Go template format for emitting a
 // ListVolumesResponse
 const listVolumesFormat = `{{range $k, $v := .Entries}}` +
-	`{{with $v.VolumeInfo}}` + volumeInfoFormat + `{{end}}` +
+	`{{with $v.Volume}}` + volumeInfoFormat + `{{end}}` +
 	`{{end}}` + // {{range $v .Entries}}
 	`{{if .NextToken}}{{printf "token=%q\n" .NextToken}}{{end}}`
 


### PR DESCRIPTION
This change is required because CSI spec renamed `VolumeInfo` to `Volume`
and `csc controller list-volumes` fails with template execution error.

```
template: t:1:37: executing "t" at <$v.VolumeInfo>: can't evaluate field VolumeInfo in type *csi.ListVolumesResponse_Entry
```

The vendored CSI code already has this change.

Refer: https://github.com/container-storage-interface/spec/issues/174