### PR TITLE
csc: Add --read-only to controller publish

### DIFF
--- a/csc/cmd/controller_publish_volume.go
+++ b/csc/cmd/controller_publish_volume.go
@@ -11,9 +11,10 @@ import (
 )
 
 var controllerPublishVolume struct {
-	nodeID  string
-	caps    volumeCapabilitySliceArg
-	attribs mapOfStringArg
+	nodeID   string
+	caps     volumeCapabilitySliceArg
+	attribs  mapOfStringArg
+	readOnly bool
 }
 
 var controllerPublishVolumeCmd = &cobra.Command{
@@ -32,6 +33,7 @@ USAGE
 			NodeId: controllerPublishVolume.nodeID,
 			ControllerPublishSecrets: root.secrets,
 			VolumeAttributes:         controllerPublishVolume.attribs.data,
+			Readonly:                 controllerPublishVolume.readOnly,
 		}
 
 		if len(controllerPublishVolume.caps.data) > 0 {
@@ -77,6 +79,12 @@ func init() {
 		false,
 		`Marks the request's NodeId field as required.
         Enabling this option also enables --with-spec-validation.`)
+
+	controllerPublishVolumeCmd.Flags().BoolVar(
+		&controllerPublishVolume.readOnly,
+		"read-only",
+		false,
+		"Mark the volume as read-only")
 
 	controllerPublishVolumeCmd.Flags().BoolVar(
 		&root.withRequiresPubVolInfo,

--- a/csc/cmd/node_stage_volume.go
+++ b/csc/cmd/node_stage_volume.go
@@ -15,7 +15,6 @@ var nodeStageVolume struct {
 	stagingTargetPath string
 	pubInfo           mapOfStringArg
 	attribs           mapOfStringArg
-	readOnly          bool
 	caps              volumeCapabilitySliceArg
 }
 
@@ -77,12 +76,6 @@ func init() {
         the request as its PublishInfo field:
 
                 --pub-info key1=val1,key2=val2 --pub-infoparams=key3=val3`)
-
-	nodeStageVolumeCmd.Flags().BoolVar(
-		&nodeStageVolume.readOnly,
-		"read-only",
-		false,
-		"Mark the volume as read-only")
 
 	nodeStageVolumeCmd.Flags().BoolVar(
 		&root.withRequiresPubVolInfo,


### PR DESCRIPTION
CSI ControllerPublishVolumeRequest supports passing Readonly attribute.

NodeStageVolumeRequest does not supports passing Readonly attribute.
This change removes that.