### PR TITLE
Adding support for Controller CreateSnapshot RPC

### DIFF
--- a/csc/cmd/controller_create_snapshot.go
+++ b/csc/cmd/controller_create_snapshot.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -44,6 +45,9 @@ CREATING MULTIPLE SNAPSHOTS
 
 			// Set the volume name for the current request.
 			req.Name = args[i]
+			if createSnapshot.sourceVol == "" {
+				return fmt.Errorf("--source-volume MUST be provided")
+			}
 
 			log.WithField("request", req).Debug("creating snapshot")
 			rep, err := controller.client.CreateSnapshot(ctx, &req)

--- a/csc/cmd/controller_create_snapshot.go
+++ b/csc/cmd/controller_create_snapshot.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"context"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+)
+
+var createSnapshot struct {
+	sourceVol string
+	params    mapOfStringArg
+	reqCreds  bool
+}
+
+var createSnapshotCmd = &cobra.Command{
+	Use:     "create-snapshot",
+	Aliases: []string{"s", "snap"},
+	Short:   `invokes the rpc "CreateSnapshot"`,
+	Example: `
+CREATING MULTIPLE SNAPSHOTS
+        The following example illustrates how to create two snapshots with the
+        same characteristics at the same time:
+
+            csc controller snap --endpoint /csi/server.sock
+							    --source-vol MySourceVolume
+                                MyNewSnapshot1 MyNewSnapshot2
+`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		req := csi.CreateSnapshotRequest{
+			SourceVolumeId:        createSnapshot.sourceVol,
+			Parameters:            createSnapshot.params.data,
+			CreateSnapshotSecrets: root.secrets,
+		}
+
+		for i := range args {
+			ctx, cancel := context.WithTimeout(root.ctx, root.timeout)
+			defer cancel()
+
+			// Set the volume name for the current request.
+			req.Name = args[i]
+
+			log.WithField("request", req).Debug("creating snapshot")
+			rep, err := controller.client.CreateSnapshot(ctx, &req)
+			if err != nil {
+				return err
+			}
+			if err := root.tpl.Execute(os.Stdout, rep.Snapshot); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	controllerCmd.AddCommand(createSnapshotCmd)
+
+	createSnapshotCmd.Flags().StringVar(
+		&createSnapshot.sourceVol,
+		"source-volume",
+		"",
+		"The source volume to snapshot")
+
+	createSnapshotCmd.Flags().Var(
+		&createSnapshot.params,
+		"params",
+		`One or more key/value pairs may be specified to send with
+        the request as its Parameters field:
+
+            --params key1=val1,key2=val2 --params=key3=val3`)
+
+	flagWithRequiresCreds(
+		createSnapshotCmd.Flags(),
+		&root.withRequiresCreds,
+		"")
+
+	flagWithRequiresAttribs(
+		createSnapshotCmd.Flags(),
+		&root.withRequiresVolumeAttributes,
+		"")
+}

--- a/csc/cmd/formats.go
+++ b/csc/cmd/formats.go
@@ -7,6 +7,11 @@ const volumeInfoFormat = `{{printf "%q\t%d" .Id .CapacityBytes}}` +
 	`{{range $k, $v := .Attributes}}{{printf "%q=%q\t" $k $v}}{{end}}` +
 	`{{end}}{{"\n"}}`
 
+// volumeInfoFormat is the default Go template format for emitting a
+// csi.SnapshotInfo
+const snapshotInfoFormat = `{{printf "%q\t%d\t%s\t%d\t%s"}}` +
+	`{{.Id .SizeBytes .SourceVolumeId .CreatedAt .Status}}`
+
 // listVolumesFormat is the default Go template format for emitting a
 // ListVolumesResponse
 const listVolumesFormat = `{{range $k, $v := .Entries}}` +

--- a/csc/cmd/root.go
+++ b/csc/cmd/root.go
@@ -84,6 +84,8 @@ var RootCmd = &cobra.Command{
 				} else {
 					root.format = listVolumesFormat
 				}
+			case createSnapshotCmd.Name():
+				root.format = snapshotInfoFormat
 			case createVolumeCmd.Name():
 				root.format = volumeInfoFormat
 			case pluginInfoCmd.Name():

--- a/mock/service/controller.go
+++ b/mock/service/controller.go
@@ -276,7 +276,11 @@ func (s *service) CreateSnapshot(
 	req *csi.CreateSnapshotRequest) (
 	*csi.CreateSnapshotResponse, error) {
 
-	return nil, status.Error(codes.Unimplemented, "snapshot unsupported")
+	// return nil, status.Error(codes.Unimplemented, "snapshot unsupported")
+	snap := s.newSnapshot(req.Name, tib)
+	return &csi.CreateSnapshotResponse{
+		Snapshot: &snap,
+	}, nil
 }
 
 func (s *service) DeleteSnapshot(


### PR DESCRIPTION
This implements create-snapshot for the controller csc command.  It adds a format template and the command itself.