### PR TITLE
Adding support for NodeGetInfo RPC

### DIFF
--- a/csc/cmd/formats.go
+++ b/csc/cmd/formats.go
@@ -57,3 +57,5 @@ const statsFormat = `{{printf "%s\t%s\t" .Name .Path}}` +
 	`{{range .Resp.Usage}}` +
 	`{{printf "%d\t%d\t%d\t%s\n" .Available .Total .Used .Unit}}` +
 	`{{end}}`
+
+const nodeInfoFormat = `{{printf "%s\t%d\t%#v\n" .NodeId .MaxVolumesPerNode .AccessibleTopology}}`

--- a/csc/cmd/node_get_info.go
+++ b/csc/cmd/node_get_info.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"context"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+)
+
+var nodeGetInfoCmd = &cobra.Command{
+	Use:     "get-info",
+	Aliases: []string{"info"},
+	Short:   `invokes the rpc "NodeGetInfo"`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		ctx, cancel := context.WithTimeout(root.ctx, root.timeout)
+		defer cancel()
+
+		rep, err := node.client.NodeGetInfo(ctx, &csi.NodeGetInfoRequest{})
+		if err != nil {
+			return err
+		}
+
+		return root.tpl.Execute(os.Stdout, rep)
+	},
+}
+
+func init() {
+	nodeCmd.AddCommand(nodeGetInfoCmd)
+
+	nodeGetInfoCmd.Flags().BoolVar(
+		&root.withRequiresNodeID,
+		"with-requires-node-id",
+		false,
+		"marks the response's node ID as a required field")
+}

--- a/csc/cmd/root.go
+++ b/csc/cmd/root.go
@@ -102,6 +102,8 @@ var RootCmd = &cobra.Command{
 				root.format = probeFormat
 			case nodeGetVolumeStatsCmd.Name():
 				root.format = statsFormat
+			case nodeGetInfoCmd.Name():
+				root.format = nodeInfoFormat
 			}
 		}
 		if root.format != "" {


### PR DESCRIPTION
The service, mocks and tests for NodeGetInfo already exist.  This is just adding support for it in the csc CLI tool