### PR TITLE
Rename PubInfo to Pub Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,12 +259,12 @@ environment variables:
       </td>
     </tr>
     <tr>
-      <td><code>X_CSI_REQUIRE_PUB_VOL_INFO</code></td>
+      <td><code>X_CSI_REQUIRE_PUB_VOL_CONTEXT</code></td>
       <td>
         <p>A flag that enables treating the following fields as required:</p>
         <ul>
-          <li><code>ControllerPublishVolumeResponse.PublishVolumeInfo</code></li>
-          <li><code>NodePublishVolumeRequest.PublishVolumeInfo</code></li>
+          <li><code>ControllerPublishVolumeResponse.PublishVolumeContext</code></li>
+          <li><code>NodePublishVolumeRequest.PublishVolumeContext</code></li>
         </ul>
         <p>Enabling this option sets <code>X_CSI_SPEC_REQ_VALIDATION=true</code></p>
       </td>

--- a/csc/cmd/controller_publish_volume.go
+++ b/csc/cmd/controller_publish_volume.go
@@ -87,10 +87,10 @@ func init() {
 		"Mark the volume as read-only")
 
 	controllerPublishVolumeCmd.Flags().BoolVar(
-		&root.withRequiresPubVolInfo,
-		"with-requires-pub-info",
+		&root.withRequiresPubVolContext,
+		"with-requires-pub-context",
 		false,
-		`Marks the response's PublishVolumeInfo field as required.
+		`Marks the response's PublishVolumeContext field as required.
         Enabling this option also enables --with-spec-validation.`)
 
 	flagVolumeAttributes(

--- a/csc/cmd/interceptors.go
+++ b/csc/cmd/interceptors.go
@@ -43,7 +43,7 @@ func getClientInterceptorsDialOpt() grpc.DialOption {
 	root.withSpecValidator = root.withSpecValidator ||
 		root.withRequiresCreds ||
 		root.withRequiresNodeID ||
-		root.withRequiresPubVolInfo ||
+		root.withRequiresPubVolContext ||
 		root.withRequiresVolumeAttributes
 	if root.withSpecValidator {
 		var specOpts []specvalidator.Option
@@ -62,10 +62,10 @@ func getClientInterceptorsDialOpt() grpc.DialOption {
 				specvalidator.WithRequiresNodeID())
 			log.Debug("enabled spec validator opt: requires node ID")
 		}
-		if root.withRequiresPubVolInfo {
+		if root.withRequiresPubVolContext {
 			specOpts = append(specOpts,
-				specvalidator.WithRequiresPublishInfo())
-			log.Debug("enabled spec validator opt: requires pub vol info")
+				specvalidator.WithRequiresPublishContext())
+			log.Debug("enabled spec validator opt: requires pub vol context")
 		}
 		if root.withRequiresVolumeAttributes {
 			specOpts = append(specOpts,

--- a/csc/cmd/node_publish_volume.go
+++ b/csc/cmd/node_publish_volume.go
@@ -13,7 +13,7 @@ import (
 var nodePublishVolume struct {
 	targetPath        string
 	stagingTargetPath string
-	pubInfo           mapOfStringArg
+	pubCtx            mapOfStringArg
 	attribs           mapOfStringArg
 	readOnly          bool
 	caps              volumeCapabilitySliceArg
@@ -34,7 +34,7 @@ USAGE
 		req := csi.NodePublishVolumeRequest{
 			StagingTargetPath: nodePublishVolume.stagingTargetPath,
 			TargetPath:        nodePublishVolume.targetPath,
-			PublishContext:    nodePublishVolume.pubInfo.data,
+			PublishContext:    nodePublishVolume.pubCtx.data,
 			Readonly:          nodePublishVolume.readOnly,
 			Secrets:           root.secrets,
 			VolumeContext:     nodePublishVolume.attribs.data,
@@ -80,12 +80,12 @@ func init() {
 		"The path to which to mount the volume")
 
 	nodePublishVolumeCmd.Flags().Var(
-		&nodePublishVolume.pubInfo,
-		"pub-info",
+		&nodePublishVolume.pubCtx,
+		"pub-context",
 		`One or more key/value pairs may be specified to send with
-        the request as its PublishVolumeInfo field:
+        the request as its PublishContext field:
 
-                --pub-info key1=val1,key2=val2 --pub-infoparams=key3=val3`)
+                --pub-context key1=val1,key2=val2`)
 
 	nodePublishVolumeCmd.Flags().BoolVar(
 		&nodePublishVolume.readOnly,
@@ -94,10 +94,10 @@ func init() {
 		"Mark the volume as read-only")
 
 	nodePublishVolumeCmd.Flags().BoolVar(
-		&root.withRequiresPubVolInfo,
+		&root.withRequiresPubVolContext,
 		"with-requires-pub-info",
 		false,
-		`Marks the request's PublishInfo field as required.
+		`Marks the request's PublishContext field as required.
         Enabling this option also enables --with-spec-validation.`)
 
 	flagVolumeAttributes(

--- a/csc/cmd/node_stage_volume.go
+++ b/csc/cmd/node_stage_volume.go
@@ -13,7 +13,7 @@ import (
 var nodeStageVolume struct {
 	nodeID            string
 	stagingTargetPath string
-	pubInfo           mapOfStringArg
+	pubCtx            mapOfStringArg
 	attribs           mapOfStringArg
 	caps              volumeCapabilitySliceArg
 }
@@ -31,7 +31,7 @@ USAGE
 
 		req := csi.NodeStageVolumeRequest{
 			StagingTargetPath: nodeStageVolume.stagingTargetPath,
-			PublishContext:    nodeStageVolume.pubInfo.data,
+			PublishContext:    nodeStageVolume.pubCtx.data,
 			Secrets:           root.secrets,
 			VolumeContext:     nodeStageVolume.attribs.data,
 		}
@@ -70,18 +70,18 @@ func init() {
 		"The path to which to stage the volume")
 
 	nodeStageVolumeCmd.Flags().Var(
-		&nodeStageVolume.pubInfo,
-		"pub-info",
+		&nodeStageVolume.pubCtx,
+		"pub-context",
 		`One or more key/value pairs may be specified to send with
-        the request as its PublishInfo field:
+        the request as its PublishContext field:
 
-                --pub-info key1=val1,key2=val2 --pub-infoparams=key3=val3`)
+                --pub-context key1=val1,key2=val2`)
 
 	nodeStageVolumeCmd.Flags().BoolVar(
-		&root.withRequiresPubVolInfo,
-		"with-requires-pub-info",
+		&root.withRequiresPubVolContext,
+		"with-requires-pub-context",
 		false,
-		`Marks the request's PublishInfo field as required.
+		`Marks the request's PublisContext field as required.
         Enabling this option also enables --with-spec-validation.`)
 
 	flagVolumeAttributes(

--- a/csc/cmd/root.go
+++ b/csc/cmd/root.go
@@ -40,7 +40,7 @@ var root struct {
 	withSpecValidator            bool
 	withRequiresCreds            bool
 	withRequiresNodeID           bool
-	withRequiresPubVolInfo       bool
+	withRequiresPubVolContext    bool
 	withRequiresVolumeAttributes bool
 }
 

--- a/envvars.go
+++ b/envvars.go
@@ -125,11 +125,11 @@ const (
 	// StagingTargetPath is required.
 	EnvVarRequireStagingTargetPath = "X_CSI_REQUIRE_STAGING_TARGET_PATH"
 
-	// EnvVarRequirePubVolInfo is the name of the environment variable used
-	// to determine whether or not publish volume info is required for
+	// EnvVarRequirePubVolContext is the name of the environment variable used
+	// to determine whether or not publish volume context is required for
 	// requests that accept it and responses that return it such as
 	// NodePublishVolume and ControllerPublishVolume.
-	EnvVarRequirePubVolInfo = "X_CSI_REQUIRE_PUB_VOL_INFO"
+	EnvVarRequirePubVolContext = "X_CSI_REQUIRE_PUB_VOL_CONTEXT"
 
 	// EnvVarRequireVolAttribs is the name of the environment variable used
 	// to determine whether or not volume attributes are required for

--- a/middleware.go
+++ b/middleware.go
@@ -29,7 +29,7 @@ func (sp *StoragePlugin) initInterceptors(ctx context.Context) {
 		withSpec               = sp.getEnvBool(ctx, EnvVarSpecValidation)
 		withStgTgtPath         = sp.getEnvBool(ctx, EnvVarRequireStagingTargetPath)
 		withNodeID             = sp.getEnvBool(ctx, EnvVarRequireNodeID)
-		withPubVolInfo         = sp.getEnvBool(ctx, EnvVarRequirePubVolInfo)
+		withPubVolContext      = sp.getEnvBool(ctx, EnvVarRequirePubVolContext)
 		withVolAttribs         = sp.getEnvBool(ctx, EnvVarRequireVolAttribs)
 		withCreds              = sp.getEnvBool(ctx, EnvVarCreds)
 		withCredsNewVol        = sp.getEnvBool(ctx, EnvVarCredsCreateVol)
@@ -63,7 +63,7 @@ func (sp *StoragePlugin) initInterceptors(ctx context.Context) {
 		withSpecReq = withCreds ||
 			withStgTgtPath ||
 			withNodeID ||
-			withPubVolInfo ||
+			withPubVolContext ||
 			withVolAttribs
 		log.WithField("withSpecReq", withSpecReq).Debug(
 			"init implicit req validation")
@@ -167,9 +167,9 @@ func (sp *StoragePlugin) initInterceptors(ctx context.Context) {
 				specvalidator.WithRequiresNodeID())
 			log.Debug("enabled spec validator opt: requires node ID")
 		}
-		if withPubVolInfo {
+		if withPubVolContext {
 			specOpts = append(specOpts,
-				specvalidator.WithRequiresPublishInfo())
+				specvalidator.WithRequiresPublishContext())
 			log.Debug("enabled spec validator opt: requires pub info")
 		}
 		if withVolAttribs {

--- a/middleware/specvalidator/spec_validator.go
+++ b/middleware/specvalidator/spec_validator.go
@@ -26,7 +26,7 @@ type opts struct {
 	repValidation               bool
 	requiresStagingTargetPath   bool
 	requiresNodeID              bool
-	requiresPubVolInfo          bool
+	requiresPubVolContext       bool
 	requiresVolAttribs          bool
 	requiresCtlrNewVolSecrets   bool
 	requiresCtlrDelVolSecrets   bool
@@ -71,9 +71,9 @@ func WithRequiresStagingTargetPath() Option {
 // WithRequiresPublishInfo is a Option that indicates
 // ControllerPublishVolume responses and NodePublishVolume requests must
 // contain non-empty publish volume info data.
-func WithRequiresPublishInfo() Option {
+func WithRequiresPublishContext() Option {
 	return func(o *opts) {
-		o.requiresPubVolInfo = true
+		o.requiresPubVolContext = true
 	}
 }
 
@@ -479,7 +479,7 @@ func (s *interceptor) validateNodeStageVolumeRequest(
 			codes.InvalidArgument, "required: StagingTargetPath")
 	}
 
-	if s.opts.requiresPubVolInfo && len(req.PublishContext) == 0 {
+	if s.opts.requiresPubVolContext && len(req.PublishContext) == 0 {
 		return status.Error(
 			codes.InvalidArgument, "required: PublishContext")
 	}
@@ -508,7 +508,7 @@ func (s *interceptor) validateNodePublishVolumeRequest(
 			codes.InvalidArgument, "required: TargetPath")
 	}
 
-	if s.opts.requiresPubVolInfo && len(req.PublishContext) == 0 {
+	if s.opts.requiresPubVolContext && len(req.PublishContext) == 0 {
 		return status.Error(
 			codes.InvalidArgument, "required: PublishContext")
 	}
@@ -559,7 +559,7 @@ func (s *interceptor) validateControllerPublishVolumeResponse(
 	ctx context.Context,
 	rep csi.ControllerPublishVolumeResponse) error {
 
-	if s.opts.requiresPubVolInfo && len(rep.PublishContext) == 0 {
+	if s.opts.requiresPubVolContext && len(rep.PublishContext) == 0 {
 		return status.Error(codes.Internal, "empty: PublishContext")
 	}
 	return nil

--- a/mock/provider/provider.go
+++ b/mock/provider/provider.go
@@ -47,7 +47,7 @@ func New() gocsi.StoragePluginProvider {
 			// Treat the following fields as required:
 			//    * ControllerPublishVolumeResponse.PublishInfo
 			//    * NodePublishVolumeRequest.PublishInfo
-			gocsi.EnvVarRequirePubVolInfo + "=true",
+			gocsi.EnvVarRequirePubVolContext + "=true",
 		},
 	}
 }

--- a/usage.go
+++ b/usage.go
@@ -131,10 +131,10 @@ GLOBAL OPTIONS
 
         Enabling this option sets X_CSI_SPEC_REQ_VALIDATION=true.
 
-    X_CSI_REQUIRE_PUB_VOL_INFO
+    X_CSI_REQUIRE_PUB_VOL_CONTEXT
         A flag that enables treating the following fields as required:
-            * ControllerPublishVolumeResponse.PublishVolumeInfo
-            * NodePublishVolumeRequest.PublishVolumeInfo
+            * ControllerPublishVolumeResponse.PublishVolumeContext
+            * NodePublishVolumeRequest.PublishVolumeContext
 
         Enabling this option sets X_CSI_SPEC_REQ_VALIDATION=true.
 


### PR DESCRIPTION
This patch brings csc more in line with the terminology used CSI 1.0 by
renameing "publish info" to "publish context" as was done in the spec.
The code was work before by remapping --pub-info to the PublishContext
field in the request, but this patch renames --pub-info (which doesn't
exist anymore) to --pub-context.