### PR TITLE
Fix #117: Snapshot listing doesn't work

### DIFF
--- a/csc/cmd/formats.go
+++ b/csc/cmd/formats.go
@@ -9,8 +9,8 @@ const volumeInfoFormat = `{{printf "%q\t%d" .VolumeId .CapacityBytes}}` +
 
 // volumeInfoFormat is the default Go template format for emitting a
 // csi.SnapshotInfo
-const snapshotInfoFormat = `{{printf "%q\t%d\t%s\t%d\t%s\n" ` +
-	`.SnapshotId .SizeBytes .SourceVolumeId .CreatedAt .Status}}`
+const snapshotInfoFormat = `{{printf "%q\t%d\t%s\t%s\t%t\n" ` +
+	`.SnapshotId .SizeBytes .SourceVolumeId .CreationTime .ReadyToUse}}`
 
 // listVolumesFormat is the default Go template format for emitting a
 // ListVolumesResponse


### PR DESCRIPTION
On commit a6b15dc6c4481848a696f273fce50a929a02bc6c we updated to CSI
v1.0, but we didn't properly update the Snapshot fields, so we are
currently trying to access to fields that are no longer there: CreatedAt
and Status

These have been replaced with CreationTime and ReadyToUse.

This patch updates the code to use the right fields.