### PR TITLE
fix make csi-sp test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 /etcd.log
 default.etcd
 
+# The csi-sp test log file
+csi-sp.log
+
 # The archives built from this package.
 /*.a
 /middleware/*.a

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ dist: trusty
 
 # Select Go as the language used to run the buid.
 language: go
-go: 1.9.4
+go: 1.12
 go_import_path: github.com/rexray/gocsi
 
 jobs:

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -14,7 +14,7 @@
 
 [[constraint]]
   name = "github.com/container-storage-interface/spec"
-  version = "1.0.0"
+  version = "=1.0.0"
 
 [[constraint]]
   name = "github.com/golang/protobuf"

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,8 @@ GOCSI_SH_ENV += GOCSI_DEP_SOURCE=https://github.com/$(TRAVIS_REPO_SLUG)
 GOCSI_SH_ENV += GOCSI_DEP_REVISION=$(TRAVIS_COMMIT)
 endif
 $(CSI_SP): | $(DEP)
+	mkdir -p $(CSI_SP_DIR)
+	cp Gopkg.toml $(CSI_SP_DIR)
 	DEP=$(abspath $(DEP)) $(GOCSI_SH_ENV) ./gocsi.sh $(CSI_SP_IMPORT)
 
 csi-sp: $(CSI_SP_LOG)


### PR DESCRIPTION
fixes #119 

This is a touch hacky, but I'm changing it as part of a subsequent PR to move to Go modules anyways. The `make csi-sp` test was failing because it was pulling in the latest CSI spec, rather than the one we had specified in the Gopkg.toml file. This wasn't an issue until code went in for CSI v1.1.0 that added new methods to the CSI controller interface. I think it is completely fair that for CI, makefile originated runs of csi-sp test, that we always use the `Gopkg.toml` file from the checked out version of the code. So I took advantage of a switch within `gocsi.sh` that doesn't write a new `Gopkg.toml` file if it already exists -- I had the Makefile just copy it directly.

When doing `make csi-sp`, we should always use the Gopkg.toml file from
the checked out source. The current test was failing because once CSI
v1.1.0 was released, the Gopkg.toml file that was created by gocsi.sh
wasn't identical to the one in the repo. Furthermore, we also needed
change the version spec to use "=" to lock it down. Without the "=", the
syntax actually defaults to "^", which if using "v1.0.0" means using
anything from 1.0.0 to <2.0.0. So we were pulling in the latest spec
when we really wanted to be on 1.0.0 exactly.

Travis-CI Go version is bumped to solve a `DisallowUnknownFields` support
issue for YAML.