### PR TITLE
Add option to disable field length checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ environment variables:
       of <code>Internal</code>.</td>
     </tr>
     <tr>
+      <td><code>X_CSI_SPEC_DISABLE_LEN_CHECK</code></td>
+      <td>A flag that disables validation of CSI message field lengths.</td>
+    </tr>
+    <tr>
       <td><code>X_CSI_REQUIRE_STAGING_TARGET_PATH</code></td>
       <td>
         <p>A flag that enables treating the following fields as required:</p>

--- a/envvars.go
+++ b/envvars.go
@@ -114,6 +114,11 @@ const (
 	// a code of "Internal."
 	EnvVarSpecRepValidation = "X_CSI_SPEC_REP_VALIDATION"
 
+	// EnvVarDisableFieldLen is the name of the environment variable used
+	// to determine whether or not to disable validation of CSI request and
+	// response field lengths against the permitted lenghts defined in the spec
+	EnvVarDisableFieldLen = "X_CSI_SPEC_DISABLE_LEN_CHECK"
+
 	// EnvVarRequireStagingTargetPath is the name of the environment variable
 	// used to determine whether or not the NodePublishVolume request field
 	// StagingTargetPath is required.

--- a/middleware.go
+++ b/middleware.go
@@ -37,6 +37,7 @@ func (sp *StoragePlugin) initInterceptors(ctx context.Context) {
 		withCredsCtrlrUnpubVol = sp.getEnvBool(ctx, EnvVarCredsCtrlrUnpubVol)
 		withCredsNodeStgVol    = sp.getEnvBool(ctx, EnvVarCredsNodeStgVol)
 		withCredsNodePubVol    = sp.getEnvBool(ctx, EnvVarCredsNodePubVol)
+		withDisableFieldLen    = sp.getEnvBool(ctx, EnvVarDisableFieldLen)
 	)
 
 	// Enable all cred requirements if the general option is enabled.
@@ -169,6 +170,11 @@ func (sp *StoragePlugin) initInterceptors(ctx context.Context) {
 			specOpts = append(specOpts,
 				specvalidator.WithRequiresPublishContext())
 			log.Debug("enabled spec validator opt: requires pub context")
+		}
+		if withDisableFieldLen {
+			specOpts = append(specOpts,
+				specvalidator.WithDisableFieldLenCheck())
+			log.Debug("disabled spec validator opt: field length check")
 		}
 		sp.Interceptors = append(sp.Interceptors,
 			specvalidator.NewServerSpecValidator(specOpts...))

--- a/middleware/specvalidator/spec_validator.go
+++ b/middleware/specvalidator/spec_validator.go
@@ -33,6 +33,7 @@ type opts struct {
 	requiresCtlrUnpubVolSecrets bool
 	requiresNodeStgVolSecrets   bool
 	requiresNodePubVolSecrets   bool
+	disableFieldLenCheck        bool
 }
 
 // WithRequestValidation is a Option that enables request validation.
@@ -128,6 +129,14 @@ func WithRequiresNodeStageVolumeSecrets() Option {
 func WithRequiresNodePublishVolumeSecrets() Option {
 	return func(o *opts) {
 		o.requiresNodePubVolSecrets = true
+	}
+}
+
+// WithDisableFieldLenCheck is a Option
+// that indicates that the length of fields should not be validated
+func WithDisableFieldLenCheck() Option {
+	return func(o *opts) {
+		o.disableFieldLenCheck = true
 	}
 }
 
@@ -276,8 +285,10 @@ func (s *interceptor) validateRequest(
 	}
 
 	// Validate field sizes.
-	if err := validateFieldSizes(req); err != nil {
-		return err
+	if !s.opts.disableFieldLenCheck {
+		if err := validateFieldSizes(req); err != nil {
+			return err
+		}
 	}
 
 	// Check to see if the request has a volume ID and if it is set.
@@ -359,8 +370,10 @@ func (s *interceptor) validateResponse(
 	}
 
 	// Validate the field sizes.
-	if err := validateFieldSizes(rep); err != nil {
-		return err
+	if !s.opts.disableFieldLenCheck {
+		if err := validateFieldSizes(rep); err != nil {
+			return err
+		}
 	}
 
 	switch tobj := rep.(type) {

--- a/usage.go
+++ b/usage.go
@@ -120,6 +120,9 @@ GLOBAL OPTIONS
         Invalid responses are marshalled into a gRPC error with a code
         of "Internal."
 
+    X_CSI_SPEC_DISABLE_LEN_CHECK
+        A flag that disables validation of CSI message field lengths.
+
     X_CSI_REQUIRE_STAGING_TARGET_PATH
         A flag that enables treating the following fields as required:
             * NodePublishVolumeRequest.StagingTargetPath


### PR DESCRIPTION
This patch adds a new option to explicitly disable the checking of CSI
message field lengths against the defined maximums found in the spec.
This is in direct response to the observation of COs not adhering to
this portion of the spec and commonly sending strings that are longer
than the current default limit of 128 bytes. This leads consumers to use
GoCSI with all spec validation disabled, which minimizes it's
usefulness.

Fixes #105 
