### PR TITLE
Make NodeID required where needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,17 +248,6 @@ environment variables:
       </td>
     </tr>
     <tr>
-      <td><code>X_CSI_REQUIRE_NODE_ID</code></td>
-      <td>
-        <p>A flag that enables treating the following fields as required:</p>
-        <ul>
-          <li><code>ControllerPublishVolumeRequest.NodeId</code></li>
-          <li><code>NodeGetIdResponse.NodeId</code></li>
-      </ul>
-      <p>Enabling this option sets <code>X_CSI_SPEC_REQ_VALIDATION=true</code></p>
-      </td>
-    </tr>
-    <tr>
       <td><code>X_CSI_REQUIRE_VOL_CONTEXT</code></td>
       <td>
         <p>A flag that enables treating the following fields as required:</p>

--- a/csc/cmd/controller_publish_volume.go
+++ b/csc/cmd/controller_publish_volume.go
@@ -73,13 +73,6 @@ func init() {
 		"",
 		"The ID of the node to which to publish the volume")
 
-	controllerPublishVolumeCmd.Flags().BoolVar(
-		&root.withRequiresNodeID,
-		"with-requires-node-id",
-		false,
-		`Marks the request's NodeId field as required.
-        Enabling this option also enables --with-spec-validation.`)
-
 	flagReadOnly(
 		controllerPublishVolumeCmd.Flags(), &controllerPublishVolume.readOnly)
 

--- a/csc/cmd/interceptors.go
+++ b/csc/cmd/interceptors.go
@@ -42,7 +42,6 @@ func getClientInterceptorsDialOpt() grpc.DialOption {
 	// Configure the spec validator.
 	root.withSpecValidator = root.withSpecValidator ||
 		root.withRequiresCreds ||
-		root.withRequiresNodeID ||
 		root.withRequiresVolContext ||
 		root.withRequiresPubContext
 	if root.withSpecValidator {
@@ -56,11 +55,6 @@ func getClientInterceptorsDialOpt() grpc.DialOption {
 				specvalidator.WithRequiresNodeStageVolumeSecrets(),
 				specvalidator.WithRequiresNodePublishVolumeSecrets())
 			log.Debug("enabled spec validator opt: requires creds")
-		}
-		if root.withRequiresNodeID {
-			specOpts = append(specOpts,
-				specvalidator.WithRequiresNodeID())
-			log.Debug("enabled spec validator opt: requires node ID")
 		}
 		if root.withRequiresVolContext {
 			specOpts = append(specOpts,

--- a/csc/cmd/node_get_info.go
+++ b/csc/cmd/node_get_info.go
@@ -29,10 +29,4 @@ var nodeGetInfoCmd = &cobra.Command{
 
 func init() {
 	nodeCmd.AddCommand(nodeGetInfoCmd)
-
-	nodeGetInfoCmd.Flags().BoolVar(
-		&root.withRequiresNodeID,
-		"with-requires-node-id",
-		false,
-		"marks the response's node ID as a required field")
 }

--- a/csc/cmd/root.go
+++ b/csc/cmd/root.go
@@ -39,7 +39,6 @@ var root struct {
 
 	withSpecValidator      bool
 	withRequiresCreds      bool
-	withRequiresNodeID     bool
 	withRequiresVolContext bool
 	withRequiresPubContext bool
 }

--- a/envvars.go
+++ b/envvars.go
@@ -114,12 +114,6 @@ const (
 	// a code of "Internal."
 	EnvVarSpecRepValidation = "X_CSI_SPEC_REP_VALIDATION"
 
-	// EnvVarRequireNodeID is the name of the environment variable used
-	// to determine whether or not the node ID value is required for
-	// requests that accept it and responses that return it such as
-	// ControllerPublishVolume and GetNodeId.
-	EnvVarRequireNodeID = "X_CSI_REQUIRE_NODE_ID"
-
 	// EnvVarRequireStagingTargetPath is the name of the environment variable
 	// used to determine whether or not the NodePublishVolume request field
 	// StagingTargetPath is required.

--- a/middleware.go
+++ b/middleware.go
@@ -28,7 +28,6 @@ func (sp *StoragePlugin) initInterceptors(ctx context.Context) {
 		withSerialVol          = sp.getEnvBool(ctx, EnvVarSerialVolAccess)
 		withSpec               = sp.getEnvBool(ctx, EnvVarSpecValidation)
 		withStgTgtPath         = sp.getEnvBool(ctx, EnvVarRequireStagingTargetPath)
-		withNodeID             = sp.getEnvBool(ctx, EnvVarRequireNodeID)
 		withVolContext         = sp.getEnvBool(ctx, EnvVarRequireVolContext)
 		withPubContext         = sp.getEnvBool(ctx, EnvVarRequirePubContext)
 		withCreds              = sp.getEnvBool(ctx, EnvVarCreds)
@@ -62,7 +61,6 @@ func (sp *StoragePlugin) initInterceptors(ctx context.Context) {
 	if !withSpecReq {
 		withSpecReq = withCreds ||
 			withStgTgtPath ||
-			withNodeID ||
 			withVolContext ||
 			withPubContext
 		log.WithField("withSpecReq", withSpecReq).Debug(
@@ -161,11 +159,6 @@ func (sp *StoragePlugin) initInterceptors(ctx context.Context) {
 				specvalidator.WithRequiresStagingTargetPath())
 			log.Debug("enabled spec validator opt: " +
 				"requires starging target path")
-		}
-		if withNodeID {
-			specOpts = append(specOpts,
-				specvalidator.WithRequiresNodeID())
-			log.Debug("enabled spec validator opt: requires node ID")
 		}
 		if withVolContext {
 			specOpts = append(specOpts,

--- a/mock/provider/provider.go
+++ b/mock/provider/provider.go
@@ -40,11 +40,6 @@ func New() gocsi.StoragePluginProvider {
 			gocsi.EnvVarSpecValidation + "=true",
 
 			// Treat the following fields as required:
-			//    * ControllerPublishVolumeRequest.NodeId
-			//    * NodeGetNodeIdResponse.NodeId
-			gocsi.EnvVarRequireNodeID + "=true",
-
-			// Treat the following fields as required:
 			//   * ControllerPublishVolumeResponse.PublishContext
 			//   * NodeStageVolumeRequest.PublishContext
 			//   * NodePublishVolumeRequest.PublishContext

--- a/testing/gocsi_test.go
+++ b/testing/gocsi_test.go
@@ -36,18 +36,6 @@ func startMockServer(ctx context.Context) (*grpc.ClientConn, func(), error) {
 		}),
 	}
 
-	// Create a client-side CSI spec validator.
-	/*
-		clientSpecValidator := gocsi.NewClientSpecValidator(
-			gocsi.WithSuccessDeleteVolumeNotFound(),
-			gocsi.WithSuccessCreateVolumeAlreadyExists(),
-			gocsi.WithRequiresNodeID(),
-			gocsi.WithRequiresPublishVolumeInfo(),
-		)
-		clientOpts = append(
-			clientOpts, grpc.WithUnaryInterceptor(clientSpecValidator))
-	*/
-
 	// Create a client for the piped connection.
 	client, err := grpc.DialContext(ctx, "", clientOpts...)
 	Ω(err).ShouldNot(HaveOccurred())

--- a/usage.go
+++ b/usage.go
@@ -124,13 +124,6 @@ GLOBAL OPTIONS
         A flag that enables treating the following fields as required:
             * NodePublishVolumeRequest.StagingTargetPath
 
-    X_CSI_REQUIRE_NODE_ID
-        A flag that enables treating the following fields as required:
-            * ControllerPublishVolumeRequest.NodeId
-            * NodeGetIdResponse.NodeId
-
-        Enabling this option sets X_CSI_SPEC_REQ_VALIDATION=true.
-
     X_CSI_REQUIRE_VOL_CONTEXT
         A flag that enables treating the following fields as required:
             * ControllerPublishVolumeRequest.VolumeContext


### PR DESCRIPTION
This patch removes the spec validator  option for requiring NodeID, as
the current CSI spec makes it explicitly required for both the
NodeGetInfoResponse and the ControllerPublishVolumeRequest, so there is
no point in having a option to enable this -- we should always check for
it.

Furthermore, NodeID is actually optional for the
ControllerUnpublishVolumeRequest, and when the NodeID is blank in that
scenario the controller is supposed to unplish the volume from all
nodes. So this patch updates the mock driver to have that behavior and
adds tests to verify it.