### PR TITLE
Add option to disable logging of VolumeContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ environment variables:
       </td>
     </tr>
     <tr>
+      <td><code>X_CSI_LOG_DISABLE_VOL_CTX</code></td>
+      <td><p>A flag that disables the logging of the VolumeContext field.</p>
+      <p>Only takes effect if Request or Reply logging is enabled.</p>
+      </td>
+    </tr>
+    <tr>
       <td><code>X_CSI_REQ_ID_INJECTION</code></td>
       <td>A flag that enables request ID injection. The ID is parsed from
       the incoming request's metadata with a key of

--- a/envvars.go
+++ b/envvars.go
@@ -92,6 +92,14 @@ const (
 	// response logging to STDOUT.
 	EnvVarRepLogging = "X_CSI_REP_LOGGING"
 
+	// EnvVarLoggingDisableVolCtx is the name of the environment variable
+	// used to disable the logging of the VolumeContext field when request or
+	// response logging is enabled.
+	//
+	// Setting this environment variable to a truthy value disables the logging
+	// of the VolumeContext field
+	EnvVarLoggingDisableVolCtx = "X_CSI_LOG_DISABLE_VOL_CTX"
+
 	// EnvVarReqIDInjection is the name of the environment variable
 	// used to determine whether or not to enable request ID injection.
 	EnvVarReqIDInjection = "X_CSI_REQ_ID_INJECTION"

--- a/middleware.go
+++ b/middleware.go
@@ -25,6 +25,7 @@ func (sp *StoragePlugin) initInterceptors(ctx context.Context) {
 	var (
 		withReqLogging         = sp.getEnvBool(ctx, EnvVarReqLogging)
 		withRepLogging         = sp.getEnvBool(ctx, EnvVarRepLogging)
+		withDisableLogVolCtx   = sp.getEnvBool(ctx, EnvVarLoggingDisableVolCtx)
 		withSerialVol          = sp.getEnvBool(ctx, EnvVarSerialVolAccess)
 		withSpec               = sp.getEnvBool(ctx, EnvVarSpecValidation)
 		withStgTgtPath         = sp.getEnvBool(ctx, EnvVarRequireStagingTargetPath)
@@ -90,6 +91,11 @@ func (sp *StoragePlugin) initInterceptors(ctx context.Context) {
 			loggingOpts []logging.Option
 			w           = newLogger(log.Debugf)
 		)
+
+		if withDisableLogVolCtx {
+			loggingOpts = append(loggingOpts, logging.WithDisableLogVolumeContext())
+			log.Debug("disabled logging of VolumeContext field")
+		}
 
 		if withReqLogging {
 			loggingOpts = append(loggingOpts, logging.WithRequestLogging(w))

--- a/usage.go
+++ b/usage.go
@@ -101,6 +101,11 @@ GLOBAL OPTIONS
 
         Enabling this option sets X_CSI_REQ_ID_INJECTION=true.
 
+    X_CSI_LOG_DISABLE_VOL_CTX
+        A flag that disables the logging of the VolumeContext field.
+
+        Only takes effect if Request or Reply logging is enabled.
+
     X_CSI_REQ_ID_INJECTION
         A flag that enables request ID injection. The ID is parsed from
         the incoming request's metadata with a key of "csi.requestid".


### PR DESCRIPTION
For some users, the "VolumeContext" field may contain sensitive data
that should not be logged. To preserve backwards compatibility, we still
log all fields but "secrets" by default, but now add a flag that can be
used to explicitly disable logging of "Volume Context".