### PR TITLE
csc: Add format for volume expansion capability

### DIFF
--- a/csc/cmd/formats.go
+++ b/csc/cmd/formats.go
@@ -44,6 +44,9 @@ const pluginCapsFormat = `{{range $v := .Capabilities}}` +
 	`{{if isa $t "*csi.PluginCapability_Service_"}}{{if $t.Service}}` +
 	`{{printf "%s\n" $t.Service.Type}}` +
 	`{{end}}{{end}}` +
+	`{{if isa $t "*csi.PluginCapability_VolumeExpansion_"}}{{if $t.VolumeExpansion}}` +
+	`{{printf "%s\n" $t.VolumeExpansion.Type}}` +
+	`{{end}}{{end}}` +
 	`{{end}}` +
 	`{{end}}`
 


### PR DESCRIPTION
With this, `PluginCapability_VolumeExpansion` is not ignored by the
csc formatter when rendering the received plugin capability list.

Before:
```
# csc -e csi.sock identity plugin-capabilities
CONTROLLER_SERVICE
```
After:
```
# csc -e csi.sock identity plugin-capabilities
CONTROLLER_SERVICE
ONLINE
```
