### PR TITLE
CSI spec 1.2.0

### DIFF
--- a/csc/cmd/controller_expand_volume.go
+++ b/csc/cmd/controller_expand_volume.go
@@ -13,6 +13,7 @@ import (
 var expandVolume struct {
 	reqBytes int64
 	limBytes int64
+	volCap   *volumeCapabilitySliceArg
 }
 
 var expandVolumeCmd = &cobra.Command{
@@ -28,7 +29,8 @@ USAGE
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		req := csi.ControllerExpandVolumeRequest{
-			Secrets: root.secrets,
+			Secrets:          root.secrets,
+			VolumeCapability: expandVolume.volCap.data[0],
 		}
 
 		if expandVolume.reqBytes > 0 || expandVolume.limBytes > 0 {
@@ -67,6 +69,8 @@ func init() {
 	flagRequiredBytes(expandVolumeCmd.Flags(), &expandVolume.reqBytes)
 
 	flagLimitBytes(expandVolumeCmd.Flags(), &expandVolume.limBytes)
+
+	flagVolumeCapability(expandVolumeCmd.Flags(), expandVolume.volCap)
 
 	flagWithRequiresCreds(
 		expandVolumeCmd.Flags(),

--- a/csc/cmd/controller_list_snapshots.go
+++ b/csc/cmd/controller_list_snapshots.go
@@ -32,6 +32,7 @@ var listSnapshotsCmd = &cobra.Command{
 			StartingToken:  listSnapshots.startingToken,
 			SnapshotId:     listSnapshots.SnapshotId,
 			SourceVolumeId: listSnapshots.sourceVolumeId,
+			Secrets:        root.secrets,
 		}
 
 		// If auto-paging is not enabled then send a normal request.

--- a/csc/cmd/node_expand_volume.go
+++ b/csc/cmd/node_expand_volume.go
@@ -11,9 +11,10 @@ import (
 )
 
 var nodeExpandVolume struct {
-	reqBytes int64
-	limBytes int64
-	volPath  string
+	reqBytes    int64
+	limBytes    int64
+	stagingPath string
+	volCap      *volumeCapabilitySliceArg
 }
 
 var nodeExpandVolumeCmd = &cobra.Command{
@@ -30,8 +31,10 @@ USAGE
 
 		// Set the volume name and path for the current request.
 		req := csi.NodeExpandVolumeRequest{
-			VolumeId:   args[0],
-			VolumePath: args[1],
+			VolumeId:          args[0],
+			VolumePath:        args[1],
+			StagingTargetPath: nodeExpandVolume.stagingPath,
+			VolumeCapability:  nodeExpandVolume.volCap.data[0],
 		}
 
 		if nodeExpandVolume.reqBytes > 0 || nodeExpandVolume.limBytes > 0 {
@@ -66,4 +69,7 @@ func init() {
 
 	flagLimitBytes(nodeExpandVolumeCmd.Flags(), &nodeExpandVolume.limBytes)
 
+	flagStagingTargetPath(nodeExpandVolumeCmd.Flags(), &nodeExpandVolume.stagingPath)
+
+	flagVolumeCapability(nodeExpandVolumeCmd.Flags(), nodeExpandVolume.volCap)
 }

--- a/csc/cmd/node_get_volume_stats.go
+++ b/csc/cmd/node_get_volume_stats.go
@@ -11,21 +11,13 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
-var nodeGetVolumeStats struct {
-	nodeID            string
-	stagingTargetPath string
-	pubInfo           mapOfStringArg
-	attribs           mapOfStringArg
-	caps              volumeCapabilitySliceArg
-}
-
 var nodeGetVolumeStatsCmd = &cobra.Command{
 	Use:   "stats",
 	Short: `invokes the rpc "NodeGetVolumeStats"`,
 	Example: `
 USAGE
 
-	csc node stats VOLUME_ID:VOLUME_PATH [VOLUME_ID:VOLUME_PATh...]
+	csc node stats VOLUME_ID:VOLUME_PATH:STAGING_PATH [VOLUME_ID:VOLUME_PATH:STAGING_PATH...]
 `,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -39,6 +31,9 @@ USAGE
 			// Set the volume ID and volume path for the current request.
 			split := strings.Split(args[i], ":")
 			req.VolumeId, req.VolumePath = split[0], split[1]
+			if len(split) > 2 {
+				req.StagingTargetPath = split[2]
+			}
 
 			log.WithField("request", req).Debug("staging volume")
 			rep, err := node.client.NodeGetVolumeStats(ctx, &req)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/akutz/gosync v0.1.0
 	github.com/akutz/memconn v0.1.0
-	github.com/container-storage-interface/spec v1.1.0
+	github.com/container-storage-interface/spec v1.2.0
 	github.com/coreos/bbolt v1.3.3 // indirect
 	github.com/coreos/etcd v3.3.13+incompatible
 	github.com/coreos/go-semver v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/container-storage-interface/spec v1.1.0 h1:qPsTqtR1VUPvMPeK0UnCZMtXaKGyyLPG8gj/wG6VqMs=
-github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
+github.com/container-storage-interface/spec v1.2.0 h1:bD9KIVgaVKKkQ/UbVUY9kCaH/CJbhNxe0eeB4JeJV2s=
+github.com/container-storage-interface/spec v1.2.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
 github.com/coreos/bbolt v1.3.3 h1:n6AiVyVRKQFNb6mJlwESEvvLoDyiTzXX7ORAUlkeBdY=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible h1:8F3hqu9fGYLBifCmRCJsicFqDx/D68Rt3q1JMazcgBQ=


### PR DESCRIPTION
This PR contains two commits. The first bumps the spec and dependencies to v1.2.0.

The second makes the associated updates to the `csc` command to pass new (optional) flags. Namely:
* Add optional secrets field to ListSnapshotsRequest
* Add optional staging_path to NodeGetVolumeStatsRequest and
  NodeExpandVolumeRequest
* Add optional volume_capability to ControllerExpandVolumeRequest
  and NodeExpandVolumeRequest