### PR TITLE
Don't call grpc stop before server initialized

### DIFF
--- a/gocsi.go
+++ b/gocsi.go
@@ -320,7 +320,9 @@ func (sp *StoragePlugin) Serve(ctx context.Context, lis net.Listener) error {
 // errors.
 func (sp *StoragePlugin) Stop(ctx context.Context) {
 	sp.stopOnce.Do(func() {
-		sp.server.Stop()
+		if sp.server != nil {
+			sp.server.Stop()
+		}
 		log.Info("stopped")
 	})
 }
@@ -330,7 +332,9 @@ func (sp *StoragePlugin) Stop(ctx context.Context) {
 // pending RPCs are finished.
 func (sp *StoragePlugin) GracefulStop(ctx context.Context) {
 	sp.stopOnce.Do(func() {
-		sp.server.GracefulStop()
+		if sp.server != nil {
+			sp.server.GracefulStop()
+		}
 		log.Info("gracefully stopped")
 	})
 }


### PR DESCRIPTION
When receiving a stop signal, it is possible that the GRPC server has
not yet been iniitialized. Verify that is has been before trying to stop
the server.

fixes #139 