### PR TITLE
expand volume fix

### DIFF
--- a/csc/cmd/controller_expand_volume.go
+++ b/csc/cmd/controller_expand_volume.go
@@ -29,8 +29,11 @@ USAGE
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		req := csi.ControllerExpandVolumeRequest{
-			Secrets:          root.secrets,
-			VolumeCapability: expandVolume.volCap.data[0],
+			Secrets: root.secrets,
+		}
+
+		if len(expandVolume.volCap.data) > 0 {
+			req.VolumeCapability = expandVolume.volCap.data[0]
 		}
 
 		if expandVolume.reqBytes > 0 || expandVolume.limBytes > 0 {

--- a/csc/cmd/controller_expand_volume.go
+++ b/csc/cmd/controller_expand_volume.go
@@ -13,7 +13,7 @@ import (
 var expandVolume struct {
 	reqBytes int64
 	limBytes int64
-	volCap   *volumeCapabilitySliceArg
+	volCap   volumeCapabilitySliceArg
 }
 
 var expandVolumeCmd = &cobra.Command{
@@ -70,7 +70,7 @@ func init() {
 
 	flagLimitBytes(expandVolumeCmd.Flags(), &expandVolume.limBytes)
 
-	flagVolumeCapability(expandVolumeCmd.Flags(), expandVolume.volCap)
+	flagVolumeCapability(expandVolumeCmd.Flags(), &expandVolume.volCap)
 
 	flagWithRequiresCreds(
 		expandVolumeCmd.Flags(),

--- a/csc/cmd/node_expand_volume.go
+++ b/csc/cmd/node_expand_volume.go
@@ -14,7 +14,7 @@ var nodeExpandVolume struct {
 	reqBytes    int64
 	limBytes    int64
 	stagingPath string
-	volCap      *volumeCapabilitySliceArg
+	volCap      volumeCapabilitySliceArg
 }
 
 var nodeExpandVolumeCmd = &cobra.Command{
@@ -71,5 +71,5 @@ func init() {
 
 	flagStagingTargetPath(nodeExpandVolumeCmd.Flags(), &nodeExpandVolume.stagingPath)
 
-	flagVolumeCapability(nodeExpandVolumeCmd.Flags(), nodeExpandVolume.volCap)
+	flagVolumeCapability(nodeExpandVolumeCmd.Flags(), &nodeExpandVolume.volCap)
 }

--- a/csc/cmd/node_expand_volume.go
+++ b/csc/cmd/node_expand_volume.go
@@ -34,7 +34,10 @@ USAGE
 			VolumeId:          args[0],
 			VolumePath:        args[1],
 			StagingTargetPath: nodeExpandVolume.stagingPath,
-			VolumeCapability:  nodeExpandVolume.volCap.data[0],
+		}
+
+		if len(nodeExpandVolume.volCap.data) > 0 {
+			req.VolumeCapability = expandVolume.volCap.data[0]
 		}
 
 		if nodeExpandVolume.reqBytes > 0 || nodeExpandVolume.limBytes > 0 {


### PR DESCRIPTION
**The `expand-volume` panic  (#141) comes from trying to access uninitialized pointer value in flag setting. And this can be resolved by adjusting the `expandVolume` variable structure fields.

```
var expandVolume struct {
	reqBytes int64
	limBytes int64
	volCap   *volumeCapabilitySliceArg
}
```

`volCap` is currently an uninitialized pointer variable so when `cobra` tries to parse arguments and set the variable, it ends up dereferencing nill pointer value. That said, the problem can be resolved by changing `volCap` type to `volumeCapabilitySliceArg` instead of its pointer type.

```
var expandVolume struct {
	reqBytes int64
	limBytes int64
	volCap   volumeCapabilitySliceArg
}
```

And adjusting other functions dependent of this variable.

The same fix can be applied to `node_expand_volume.go` for the same reason.**
 